### PR TITLE
Add workflow protection to prevent deploy old image

### DIFF
--- a/.github/workflows/build-integrations-webapp-dispatch-shared.yaml
+++ b/.github/workflows/build-integrations-webapp-dispatch-shared.yaml
@@ -81,27 +81,51 @@ jobs:
 
       - name: Set variable tag for jq
         run: |
-          echo "IMAGE_TAG=869898323958.dkr.ecr.us-east-1.amazonaws.com/integrations:engine-${{github.event.inputs.tag-name}}" >> $GITHUB_ENV
+          echo "IMAGE_TAG=869898323958.dkr.ecr.us-east-1.amazonaws.com/integrations:webapp-${{github.event.inputs.tag-name}}" >> $GITHUB_ENV
 
       - name: Update image on deployment
         run: |
-            sudo apt update
-            sudo apt install -y jq
-            app_dir='integrations'
-            deploy_patch_name='deployment-webapp.json'
+            which jq > /dev/null 2>&1 || ( sudo apt update ; sudo apt install -y jq )
+            # Dep: coreutils
+            verlte() {
+              [ "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
+            }
+            verlt(){
+              [ "$1" = "$2" ] && return 1 || verlte $1 $2
+            }
+            export PROJECT_DIR="integrations" PATCH_TARGET="deployment-webapp.json"
             for e in ${{github.event.inputs.destination-env}}; do
-              if [ -d "kubernetes-manifests/${app_dir}/${e}" ] ; then
-                echo 'Old image to replace:'
-                cat "kubernetes-manifests/${app_dir}/${e}/${deploy_patch_name}" | jq '.[] | select(.path == "/spec/template/spec/containers/0/image") | .value'
-                echo 'New configurations:'
-                new_configuration=$(
-                  cat "kubernetes-manifests/${app_dir}/${e}/${deploy_patch_name}" \
-                    | jq '(..|select(.path == "/spec/template/spec/containers/0/image")?) += {value: "'"${IMAGE_TAG}"'"}'
-                )
-                echo "$new_configuration"
-                echo "$new_configuration" > "kubernetes-manifests/${app_dir}/${e}/${deploy_patch_name}"
+              echo "Update ${e}:"
+              if [ ! -d "kubernetes-manifests/${PROJECT_DIR}/${e}" ] ; then
+                echo "kubernetes-manifests/${PROJECT_DIR}/${e}: Does not exist, skipping"
+              elif [ ! -r "kubernetes-manifests/${PROJECT_DIR}/${e}/kustomization.yaml" ] ; then
+                echo "kubernetes-manifests/${PROJECT_DIR}/${e}/kustomization.yaml: Does not readable, skipping"
+              elif [ ! -r "kubernetes-manifests/${PROJECT_DIR}/${e}/${PATCH_TARGET}" ] ; then
+                echo "kubernetes-manifests/${PROJECT_DIR}/${e}/${PATCH_TARGET}: Does not readable, skipping"
               else
-                echo "kubernetes-manifests/${app_dir}/${e}: Does not exist, skipping"
+                OLD_IMAGE=$(
+                  cat "kubernetes-manifests/${PROJECT_DIR}/${e}/${PATCH_TARGET}" \
+                    | jq '.[] | select(.path == "/spec/template/spec/containers/0/image") | .value'
+                )
+                echo "Old image to replace: ${OLD_IMAGE}"
+                OLD_VERSION=$(
+                  echo "${OLD_IMAGE}" \
+                    | sed s'/^.*[v:-]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/'g \
+                    | head -n1
+                )
+                NEW_VERSION=$(echo ${{github.event.inputs.tag-name}}|grep -o -e '[0-9]*\.[0-9]*\.[0-9]*')
+                echo "Old image version to compare: ${OLD_VERSION}<=${NEW_VERSION}"
+                if verlte "${OLD_VERSION}" "${NEW_VERSION}" ; then
+                  echo 'New configurations:'
+                  new_configuration=$(
+                    cat "kubernetes-manifests/${PROJECT_DIR}/${e}/${PATCH_TARGET}" \
+                      | jq '(..|select(.path == "/spec/template/spec/containers/0/image")?) += {value: "'"${{env.IMAGE_TAG}}"'"}'
+                  )
+                  echo "${new_configuration}"
+                  echo "${new_configuration}" > "kubernetes-manifests/${PROJECT_DIR}/${e}/${PATCH_TARGET}"
+                else
+                  echo "Version in file is greater than build, skiping update yaml"
+                fi
               fi
             done
 

--- a/.github/workflows/build-integrations-webapp-push-tag-shared.yaml
+++ b/.github/workflows/build-integrations-webapp-push-tag-shared.yaml
@@ -22,6 +22,11 @@ jobs:
               echo "MANIFESTS_ENVIRONMENT=develop"
               echo "TAG=$TAG" >> $GITHUB_ENV
               echo "TAG=$TAG"
+              VERSION=${TAG#v} 
+              echo "VERSION=$VERSION" >> $GITHUB_ENV
+              echo "VERSION=$VERSION"
+              echo "COMMIT_SHA=$GITHUB_SHA" >> $GITHUB_ENV
+              echo "COMMIT_SHA=$GITHUB_SHA"
               echo "IMAGE_TAG=869898323958.dkr.ecr.us-east-1.amazonaws.com/integrations:engine-$TAG" >> $GITHUB_ENV
               echo "IMAGE_TAG=869898323958.dkr.ecr.us-east-1.amazonaws.com/integrations:engine-$TAG"
             elif $(echo  $TAG|grep --silent -e 'v*.*.*-staging*')
@@ -31,6 +36,11 @@ jobs:
               echo "MANIFESTS_ENVIRONMENT=staging"
               echo "TAG=$TAG" >> $GITHUB_ENV
               echo "TAG=$TAG"
+              VERSION=${TAG#v} 
+              echo "VERSION=$VERSION" >> $GITHUB_ENV
+              echo "VERSION=$VERSION"
+              echo "COMMIT_SHA=$GITHUB_SHA" >> $GITHUB_ENV
+              echo "COMMIT_SHA=$GITHUB_SHA"
               echo "IMAGE_TAG=869898323958.dkr.ecr.us-east-1.amazonaws.com/integrations:engine-$TAG" >> $GITHUB_ENV
               echo "IMAGE_TAG=869898323958.dkr.ecr.us-east-1.amazonaws.com/integrations:engine-$TAG"
             elif $(echo  $TAG|grep --silent -e 'v*.*.*')
@@ -40,18 +50,22 @@ jobs:
               echo "MANIFESTS_ENVIRONMENT=production"
               echo "TAG=$TAG" >> $GITHUB_ENV
               echo "TAG=$TAG"
+              VERSION=${TAG#v} 
+              echo "VERSION=$VERSION" >> $GITHUB_ENV
+              echo "VERSION=$VERSION"
+              echo "COMMIT_SHA=$GITHUB_SHA" >> $GITHUB_ENV
+              echo "COMMIT_SHA=$GITHUB_SHA"
               echo "IMAGE_TAG=869898323958.dkr.ecr.us-east-1.amazonaws.com/integrations:engine-$TAG" >> $GITHUB_ENV
               echo "IMAGE_TAG=869898323958.dkr.ecr.us-east-1.amazonaws.com/integrations:engine-$TAG"
             else
               echo 'Not a valid tag. Skipping...'
               exit 1
             fi
-            echo COMMIT_SHA="$GITHUB_SHA"
 
       - name: Check out the repo
         uses: actions/checkout@v2
         with:
-          ref: ${{ env.GITHUB_SHA }}
+          ref: ${{env.GITHUB_SHA}}
           repository: Ilhasoft/weni-integrations-webapp
 
       - name: Set up QEMU
@@ -64,18 +78,18 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: 869898323958.dkr.ecr.us-east-1.amazonaws.com
-          username: ${{ secrets.AWS_ACCESS_KEY_ID_SHARED }}
-          password: ${{ secrets.AWS_SECRET_ACCESS_KEY_SHARED }}
+          username: ${{secrets.AWS_ACCESS_KEY_ID_SHARED}}
+          password: ${{secrets.AWS_SECRET_ACCESS_KEY_SHARED}}
 
       - name: Build and push - Integrations Engine Image
         id: docker_build1
         uses: docker/build-push-action@v2
         with:
           context: .
-          labels: branch=${{ env.TAG }},commit=${{ env.GITHUB_SHA }},repository=https://github.com/Ilhasoft/weni-integrations-webapp
+          labels: branch=${{env.TAG}},commit=${{env.COMMIT_SHA}},repository=https://github.com/Ilhasoft/weni-integrations-webapp
           file: Dockerfile
           push: true
-          tags: 869898323958.dkr.ecr.us-east-1.amazonaws.com/integrations:webapp-${{ env.TAG }}
+          tags: ${{env.IMAGE_TAG}}
           no-cache: true
           build-args: |
             VUE_APP_API_BASE_URL=https://integrations-engine.weni.ai
@@ -87,29 +101,52 @@ jobs:
         uses: actions/checkout@master
         with:
           ref: main
-          repository: Ilhasoft/kubernetes-manifests
-          token: ${{ secrets.CICEROW_GITHUB_PERMANENT_TOKEN }}
+          repository: Ilhasoft/kubernetes-manifests-platform
+          token: ${{secrets.CICEROW_GITHUB_PERMANENT_TOKEN}}
           path: ./kubernetes-manifests/
 
       - name: Update image on deployment
         run: |
-            sudo apt update
-            sudo apt install -y jq
-            app_dir='integrations'
-            deploy_patch_name='deployment-webapp.json'
-            for e in ${{ env.MANIFESTS_ENVIRONMENT }}; do
-              if [ -d "kubernetes-manifests/${app_dir}/${e}" ] ; then
-                echo 'Old image to replace:'
-                cat "kubernetes-manifests/${app_dir}/${e}/${deploy_patch_name}" | jq '.[] | select(.path == "/spec/template/spec/containers/0/image") | .value'
-                echo 'New configurations:'
-                new_configuration=$(
-                  cat "kubernetes-manifests/${app_dir}/${e}/${deploy_patch_name}" \
-                    | jq '(..|select(.path == "/spec/template/spec/containers/0/image")?) += {value: "'"${{ env.IMAGE_TAG }}"'"}'
-                )
-                echo "$new_configuration"
-                echo "$new_configuration" > "kubernetes-manifests/${app_dir}/${e}/${deploy_patch_name}"
+            which jq > /dev/null 2>&1 || ( sudo apt update ; sudo apt install -y jq )
+            # Dep: coreutils
+            verlte() {
+              [ "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
+            }
+            verlt(){
+              [ "$1" = "$2" ] && return 1 || verlte $1 $2
+            }
+            export PROJECT_DIR="integrations" PATCH_TARGET="deployment-webapp.json"
+            for e in ${{env.MANIFESTS_ENVIRONMENT}}; do
+              echo "Update ${e}:"
+              if [ ! -d "kubernetes-manifests/${PROJECT_DIR}/${e}" ] ; then
+                echo "kubernetes-manifests/${PROJECT_DIR}/${e}: Does not exist, skipping"
+              elif [ ! -r "kubernetes-manifests/${PROJECT_DIR}/${e}/kustomization.yaml" ] ; then
+                echo "kubernetes-manifests/${PROJECT_DIR}/${e}/kustomization.yaml: Does not readable, skipping"
+              elif [ ! -r "kubernetes-manifests/${PROJECT_DIR}/${e}/${PATCH_TARGET}" ] ; then
+                echo "kubernetes-manifests/${PROJECT_DIR}/${e}/${PATCH_TARGET}: Does not readable, skipping"
               else
-                echo "kubernetes-manifests/${app_dir}/${e}: Does not exist, skipping"
+                OLD_IMAGE=$(
+                  cat "kubernetes-manifests/${PROJECT_DIR}/${e}/${PATCH_TARGET}" \
+                    | jq '.[] | select(.path == "/spec/template/spec/containers/0/image") | .value'
+                )
+                echo "Old image to replace: ${OLD_IMAGE}"
+                OLD_VERSION=$(
+                  echo "${OLD_IMAGE}" \
+                    | sed s'/^.*[v:-]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/'g \
+                    | head -n1
+                )
+                echo "Old image version to compare: ${OLD_VERSION}<=${{env.VERSION}}"
+                if verlte "${OLD_VERSION}" "${{env.VERSION}}" ; then
+                  echo 'New configurations:'
+                  new_configuration=$(
+                    cat "kubernetes-manifests/${PROJECT_DIR}/${e}/${PATCH_TARGET}" \
+                      | jq '(..|select(.path == "/spec/template/spec/containers/0/image")?) += {value: "'"${{env.IMAGE_TAG}}"'"}'
+                  )
+                  echo "${new_configuration}"
+                  echo "${new_configuration}" > "kubernetes-manifests/${PROJECT_DIR}/${e}/${PATCH_TARGET}"
+                else
+                  echo "Version in file is greater than build, skiping update yaml"
+                fi
               fi
             done
 
@@ -117,11 +154,11 @@ jobs:
         uses: actions-js/push@master
         with:
           github_token: ${{ secrets.CICEROW_GITHUB_PERMANENT_TOKEN }}
-          repository: Ilhasoft/kubernetes-manifests
+          repository: Ilhasoft/kubernetes-manifests-platform
           directory: ./kubernetes-manifests/
           branch: main
           message: "From Integrations WebApp Build (Push-Tag)"
 
       - name: Generated Image
         run: |
-            echo "IMAGE:      " ${{ env.IMAGE_TAG }}
+            echo "IMAGE:      " ${{env.IMAGE_TAG}}


### PR DESCRIPTION
The modifications will prevent insert a tag with an old version of an image and automaticaly deploy in kubernetes cluster.