### PR TITLE
Fix: Add stop modifier on modal click

### DIFF
--- a/src/components/config/channels/wpp_demo/Config.vue
+++ b/src/components/config/channels/wpp_demo/Config.vue
@@ -6,6 +6,7 @@
     scheme="feedback-green"
     modal-icon="check-circle-1-1"
     @close="closePopUp"
+    @click.stop
   >
     <span slot="message" v-html="$t('WhatsAppDemo.config.description')"></span>
     <unnnic-button


### PR DESCRIPTION
An unwanted click propagation was happening causing the AppGrid card to be clicked when the modal received a click and the user redirected to the App details page.