### PR TITLE
Fix: Removed mocked status indicator

### DIFF
--- a/src/components/config/channels/whatsapp/components/tabs/AccountTab.vue
+++ b/src/components/config/channels/whatsapp/components/tabs/AccountTab.vue
@@ -30,7 +30,6 @@
           class="account-tab__content__section"
         >
           <div class="account-tab__content__section__title">
-            <StatusIndicator :status="section.status" />
             <span class="account-tab__content__section__title__name">
               {{ $t(`WhatsApp.config.${section.name}.title`) }}
             </span>
@@ -62,10 +61,8 @@
 </template>
 
 <script>
-  import StatusIndicator from '../StatusIndicator.vue';
   export default {
     name: 'AccountTab',
-    components: { StatusIndicator },
     props: {
       appInfo: {
         type: Object,

--- a/tests/unit/specs/components/config/channels/whatsapp/components/StatusIndicator.spec.js
+++ b/tests/unit/specs/components/config/channels/whatsapp/components/StatusIndicator.spec.js
@@ -1,0 +1,20 @@
+import { shallowMount, createLocalVue } from '@vue/test-utils';
+import StatusIndicator from '@/components/config/channels/whatsapp/components/StatusIndicator.vue';
+
+const localVue = createLocalVue();
+
+describe('whatsapp/components/StatusIndicator.vue', () => {
+  let wrapper;
+  beforeEach(() => {
+    wrapper = shallowMount(StatusIndicator, {
+      localVue,
+      propsData: {
+        status: 'green',
+      },
+    });
+  });
+
+  it('should be rendered properly', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/tests/unit/specs/components/config/channels/whatsapp/components/__snapshots__/StatusIndicator.spec.js.snap
+++ b/tests/unit/specs/components/config/channels/whatsapp/components/__snapshots__/StatusIndicator.spec.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`whatsapp/components/StatusIndicator.vue should be rendered properly 1`] = `<span class="status green"></span>`;

--- a/tests/unit/specs/components/config/channels/whatsapp/components/tabs/__snapshots__/AccountTab.spec.js.snap
+++ b/tests/unit/specs/components/config/channels/whatsapp/components/tabs/__snapshots__/AccountTab.spec.js.snap
@@ -21,11 +21,9 @@ exports[`whatsapp/components/tabs/AccountTab.vue should be rendered properly 1`]
     </div>
     <div>
       <div class="account-tab__content__section">
-        <div class="account-tab__content__section__title">
-          <statusindicator-stub status="green"></statusindicator-stub> <span class="account-tab__content__section__title__name">
+        <div class="account-tab__content__section__title"><span class="account-tab__content__section__title__name">
             some specific text
-          </span>
-        </div>
+          </span></div>
         <div class="account-tab__content__section__field">
           <div class="account-tab__content__section__field__key">
             some specific text
@@ -68,11 +66,9 @@ exports[`whatsapp/components/tabs/AccountTab.vue should be rendered properly 1`]
         </div>
       </div>
       <div class="account-tab__content__section">
-        <div class="account-tab__content__section__title">
-          <statusindicator-stub status="yellow"></statusindicator-stub> <span class="account-tab__content__section__title__name">
+        <div class="account-tab__content__section__title"><span class="account-tab__content__section__title__name">
             some specific text
-          </span>
-        </div>
+          </span></div>
         <div class="account-tab__content__section__field">
           <div class="account-tab__content__section__field__key">
             some specific text


### PR DESCRIPTION
Removed mocked status indicator from Account tab, since backend support is not yet complete