### PR TITLE
Fix: Handle empty phone number

### DIFF
--- a/src/components/config/channels/whatsapp/Config.vue
+++ b/src/components/config/channels/whatsapp/Config.vue
@@ -107,14 +107,14 @@
         } catch (error) {
           unnnicCallAlert({
             props: {
-              text: this.$t('apps.details.status_error'),
+              text: this.$t('WhatsApp.config.error.data_fetch'),
               title: 'Error',
               icon: 'alert-circle-1-1',
               scheme: 'feedback-red',
               position: 'bottom-right',
               closeText: this.$t('general.Close'),
             },
-            seconds: 3,
+            seconds: 8,
           });
         }
       },

--- a/src/components/config/channels/whatsapp/components/tabs/AccountTab.vue
+++ b/src/components/config/channels/whatsapp/components/tabs/AccountTab.vue
@@ -14,7 +14,7 @@
               size="sm"
             />
             <div class="account-tab__content__info__account__name__text">
-              {{ fieldHandler(appConfig.phone_number.display_name) }}
+              {{ fieldHandler(phoneNumber.display_name) }}
             </div>
           </div>
           <div class="account-tab__content__info__account__business">
@@ -81,6 +81,9 @@
       },
     },
     computed: {
+      phoneNumber() {
+        return this.appInfo?.config?.phone_number ?? {};
+      },
       wabaInfo() {
         return this.appInfo?.config?.waba ?? {};
       },
@@ -104,13 +107,13 @@
                 type: 'text',
                 name: 'phone_number',
                 label: 'WhatsApp.config.channel.fields.phone_number',
-                value: this.fieldHandler(this.appConfig.phone_number.display_phone_number),
+                value: this.fieldHandler(this.phoneNumber.display_phone_number),
               },
               {
                 type: 'text',
                 name: 'whatsapp_display_name',
                 label: 'WhatsApp.config.channel.fields.whatsapp_display_name',
-                value: this.fieldHandler(this.appConfig.phone_number.display_name),
+                value: this.fieldHandler(this.phoneNumber.display_name),
               },
               {
                 type: 'text',


### PR DESCRIPTION
The component would break when phone_number was not returned from the backend API.